### PR TITLE
Replace Recto with string.split()

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Recto"]
-	path = Recto
-	url = https://github.com/BrianOtto/Recto

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 _A package for constructing, comparing and matching Semantic Versions_
 
-This library uses [Recto](https://github.com/BrianOtto/Recto), a string manipulation library, which is included as a git submodule. Ironically, the whole point of this `SemVer` package is to aid creation of a Wren package manager, which will be used to include `Recto`, woah: confusing!
-
 `SemVer` exposes two constructors:
 
 + `version`: creates a single semver version, like `2.3.4`

--- a/semver.wren
+++ b/semver.wren
@@ -1,5 +1,3 @@
-import "./Recto/Recto" for Recto
-
 class SemVer {
 	matcher { _matcher }
 
@@ -26,10 +24,8 @@ class SemVer {
 	patch=(x){ _patch = x }
 
 	construct version(fullString) {
-		var recto = Recto.new()
-
 		_matcher = false
-		var levels = recto.split(fullString, ".")
+		var levels = fullString.split(".")
 
 		//sanity check:
 		for( level in levels ){
@@ -44,9 +40,8 @@ class SemVer {
 	}
 
 	construct matcher(fullString) {
-		var recto = Recto.new()
 		_matcher = true
-		var levels = recto.split(fullString, ".")
+		var levels = fullString.split(".")
 
 		_major = Num.fromString(levels[0])
 		_minor = Num.fromString(levels[1])


### PR DESCRIPTION
Recto is no longer needed since we have a string `.split()`.